### PR TITLE
Fix URL used to link to Pivotal stories.

### DIFF
--- a/src/sentry_pivotal/plugin.py
+++ b/src/sentry_pivotal/plugin.py
@@ -72,4 +72,4 @@ class PivotalTrackerPlugin(IssuePlugin):
     def get_issue_url(self, group, issue_id, **kwargs):
         project = self.get_option('project', group.project)
 
-        return 'https://www.pivotaltracker.com/projects/%s#!/stories/%s' % (project, issue_id)
+        return 'https://www.pivotaltracker.com/projects/%s/stories/%s' % (project, issue_id)


### PR DESCRIPTION
At some point Pivotal seems to have changed the URL syntax for
stories. This updates the URL to use the same format provided
within Pivotal.
