### PR TITLE
Error message on API 401 response

### DIFF
--- a/src/sentry_pivotal/plugin.py
+++ b/src/sentry_pivotal/plugin.py
@@ -61,6 +61,8 @@ class PivotalTrackerPlugin(IssuePlugin):
         try:
             project = client.projects.get(self.get_option('project', group.project))
             story = project.stories.add(story)
+        except pyvotal.exceptions.AccessDenied:
+            raise forms.ValidationError(_('Access denied through Pivotal API.'))
         except Exception, e:
             raise forms.ValidationError(_('Error communicating with Pivotal Tracker: %s') % (unicode(e),))
 


### PR DESCRIPTION
If Pivotal Member has no write access the API will raise an AccessDenied exception; exception message will be empty. To get a useful error message this exception should be cached explicitly.