### PR TITLE
Update the README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,3 +11,11 @@ Install
 Install the package via ``pip``::
 
     pip install sentry-pivotal
+
+Configuration
+--------------
+- Go to your project page (https://<sentry-url>/<organization>/<project>/settings/) and click on "Manage Integrations". 
+- Enable the "Pivotal Tracker" plugin by clicking on the checkbox next to it and then click on "Save Changes" button.
+- Now you should see the "Pivotal Tracker" option under the "INTEGRATIONS" tab or Please refresh your page.
+- Click on the "Pivotal Tracker" option and Enter the "API Token" and "Project ID" values and click on Save Changes" button.
+- Now, you should be able to see "Add Story" button the right side on the event page. 

--- a/README.rst
+++ b/README.rst
@@ -18,4 +18,4 @@ Configuration
 - Enable the "Pivotal Tracker" plugin by clicking on the checkbox next to it and then click on "Save Changes" button.
 - Now you should see the "Pivotal Tracker" option under the "INTEGRATIONS" tab or Please refresh your page.
 - Click on the "Pivotal Tracker" option and Enter the "API Token" and "Project ID" values and click on Save Changes" button.
-- Now, you should be able to see "Add Story" button the right side on the event page. 
+- Now, you should see a "Add Story" button on the right side on the event page. 


### PR DESCRIPTION
Hi, I have updated the README.rst with the configuration steps required to enable the sentry-plugin. I am new to sentry and I have spent some time in figuring out, how enable the sentry-pivotal plugin after installing it via pip. 
So, I felt like, having these configuration steps in the README.rst file, will help others in configuring it. 

Thanks,
RaviTeja
