### PR TITLE
Update plugin.py for project-independent story URL

### DIFF
--- a/src/sentry_pivotal/plugin.py
+++ b/src/sentry_pivotal/plugin.py
@@ -73,6 +73,4 @@ class PivotalTrackerPlugin(IssuePlugin):
         return '#%s' % issue_id
 
     def get_issue_url(self, group, issue_id, **kwargs):
-        project = self.get_option('project', group.project)
-
-        return 'https://www.pivotaltracker.com/projects/%s/stories/%s' % (project, issue_id)
+        return 'https://www.pivotaltracker.com/story/show/%s' % (issue_id)


### PR DESCRIPTION
(Note: I'm new to this; this is my first pull request. I apologize if I've gone about anything improperly and appreciate your patience and corrective guidance.)

This is a change to the URL saved in Sentry pointing to the Pivotal story. If it doesn't contain a Pivotal project ID, the resulting story can be moved between projects without breaking the link in Sentry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-pivotal/13)
<!-- Reviewable:end -->
